### PR TITLE
Update `handlebars` to solve `WS-2019-0064`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "rollup": "0",
     "tape": "4",
     "uglify-js": "3",
-    "handlebars": "4",
+    "handlebars": ">=4.0.14",
     "d3-selection": "1"
   },
   "dependencies": {


### PR DESCRIPTION
WS-2019-0064
high severity
Vulnerable versions: < 4.0.14
Patched version: 4.0.14
Versions of handlebars prior to 4.0.14 are vulnerable to Prototype Pollution. Templates may alter an Objects' prototype, thus allowing an attacker to execute arbitrary code on the server.